### PR TITLE
Feature/checkout as branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Note: Their name will vary depending on your material's name. For example, if yo
 | --- | --- |
 | `GO_SCM_*_PR_BRANCH` | Pull Request was submitted **from** this organisation/user and branch. Eg. `ashwankthkumar:feature-1` |
 | `GO_SCM_*_TARGET_BRANCH` | Pull Request was submitted **for** this organisation/user and branch. Eg. `ashwankthkumar:master` |
+| `GO_SCM_*_PR_CHECKOUT_BRANCH` | Local branch into which the plugin checks out the Pull Request during the build. Eg. `ashwankthkumar/feature-1` |
 | `GO_SCM_*_PR_ID` | Pull Request ID on the Github |
 | `GO_SCM_*_PR_URL` | Pull Request URL on the Github |
 | `GO_SCM_*_PR_AUTHOR_EMAIL` | Email address of the author who submitted the Pull Request. 

--- a/src/main/java/in/ashwanthkumar/gocd/github/GitHubPRBuildPlugin.java
+++ b/src/main/java/in/ashwanthkumar/gocd/github/GitHubPRBuildPlugin.java
@@ -442,7 +442,7 @@ public class GitHubPRBuildPlugin implements GoPlugin {
 
     private String determineCheckoutBranch(Map<String, String> customDataBag) {
         // Use the source branch suggested by the provider, if available:
-        String checkoutBranch = customDataBag.get("PR_BRANCH");
+        String checkoutBranch = customDataBag.getOrDefault("PR_BRANCH", customDataBag.get("CURRENT_BRANCH"));
         if (checkoutBranch == null) {
             // If not, use a generic name but include the PR identifier for reference, if available:
             // Don't use "pr" as the name because at least for Bitbucket there are already pr/ git refs.

--- a/src/main/java/in/ashwanthkumar/gocd/github/GitHubPRBuildPlugin.java
+++ b/src/main/java/in/ashwanthkumar/gocd/github/GitHubPRBuildPlugin.java
@@ -8,6 +8,9 @@ import com.thoughtworks.go.plugin.api.logging.Logger;
 import com.thoughtworks.go.plugin.api.request.GoPluginApiRequest;
 import com.thoughtworks.go.plugin.api.response.GoPluginApiResponse;
 import com.tw.go.plugin.GitHelper;
+import com.tw.go.plugin.cmd.Console;
+import com.tw.go.plugin.cmd.InMemoryConsumer;
+import com.tw.go.plugin.cmd.ProcessOutputStreamConsumer;
 import com.tw.go.plugin.model.GitConfig;
 import com.tw.go.plugin.model.ModifiedFile;
 import com.tw.go.plugin.model.Revision;
@@ -21,9 +24,11 @@ import in.ashwanthkumar.gocd.github.util.GitFolderFactory;
 import in.ashwanthkumar.gocd.github.util.JSONUtils;
 import in.ashwanthkumar.utils.collections.Lists;
 import in.ashwanthkumar.utils.func.Function;
+import org.apache.commons.exec.CommandLine;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 
+import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.text.SimpleDateFormat;
@@ -369,12 +374,23 @@ public class GitHubPRBuildPlugin implements GoPlugin {
         GitConfig gitConfig = getGitConfig(configuration);
         String destinationFolder = (String) requestBodyMap.get("destination-folder");
         Map<String, Object> revisionMap = (Map<String, Object>) requestBodyMap.get("revision");
+        Map<String, String> customDataBag = (Map<String, String>) revisionMap.getOrDefault("data", Collections.emptyMap());
         String revision = (String) revisionMap.get("revision");
         LOGGER.info(String.format("destination: %s. commit: %s", destinationFolder, revision));
 
         try {
-            GitHelper git = gitFactory.create(gitConfig, gitFolderFactory.create(destinationFolder));
+            File workDir = gitFolderFactory.create(destinationFolder);
+            GitHelper git = gitFactory.create(gitConfig, workDir);
             git.cloneOrFetch(provider.getRefSpec());
+
+            String branch = customDataBag.getOrDefault("PR_CHECKOUT_BRANCH", "gocd-pr");
+            // TODO: this should be moved into the git-cmd library, or just provide an easy way to execute
+            // arbitrary git commands (without all the plumbing needed here).
+            CommandLine gitCheckout = Console.createCommand(new String[]{"checkout", "-B", branch});
+            ProcessOutputStreamConsumer stdOut = new ProcessOutputStreamConsumer(new InMemoryConsumer());
+            ProcessOutputStreamConsumer stdErr = new ProcessOutputStreamConsumer(new InMemoryConsumer());
+            Console.runOrBomb(gitCheckout, workDir, stdOut, stdErr);
+
             git.resetHard(revision);
             git.submoduleUpdate();
 
@@ -427,6 +443,15 @@ public class GitHubPRBuildPlugin implements GoPlugin {
         response.put("modifiedFiles", modifiedFilesMapList);
         Map<String, String> customDataBag = new HashMap<String, String>();
         provider.populateRevisionData(gitConfig, branch, revision.getRevision(), customDataBag);
+
+        // Don't use "pr" because at least for Bitbucke there are already pr/ git refs.
+        // TODO: for providers that return the source branch, it should use that.
+        String checkoutBranch = "gocd-pr";
+        if (customDataBag.containsKey("PR_ID")) {
+            checkoutBranch += "/" + customDataBag.get("PR_ID");
+        }
+        customDataBag.put("PR_CHECKOUT_BRANCH", checkoutBranch);
+
         response.put("data", customDataBag);
         return response;
     }

--- a/src/main/java/in/ashwanthkumar/gocd/github/util/ExtendedGitCmdHelper.java
+++ b/src/main/java/in/ashwanthkumar/gocd/github/util/ExtendedGitCmdHelper.java
@@ -1,0 +1,26 @@
+package in.ashwanthkumar.gocd.github.util;
+
+import java.io.File;
+
+import com.tw.go.plugin.cmd.Console;
+import com.tw.go.plugin.cmd.ProcessOutputStreamConsumer;
+import com.tw.go.plugin.git.GitCmdHelper;
+import com.tw.go.plugin.model.GitConfig;
+import org.apache.commons.exec.CommandLine;
+
+public class ExtendedGitCmdHelper extends GitCmdHelper {
+
+    public ExtendedGitCmdHelper(GitConfig gitConfig, File workingDir) {
+        super(gitConfig, workingDir);
+    }
+
+    public ExtendedGitCmdHelper(GitConfig gitConfig, File workingDir, ProcessOutputStreamConsumer stdOut,
+            ProcessOutputStreamConsumer stdErr) {
+        super(gitConfig, workingDir, stdOut, stdErr);
+    }
+
+    public void checkoutNewBranch(String branchName) {
+        CommandLine gitCheckout = Console.createCommand("checkout", "-B", branchName);
+        Console.runOrBomb(gitCheckout, workingDir, stdOut, stdErr);
+    }
+}

--- a/src/main/java/in/ashwanthkumar/gocd/github/util/GitFactory.java
+++ b/src/main/java/in/ashwanthkumar/gocd/github/util/GitFactory.java
@@ -1,15 +1,13 @@
 package in.ashwanthkumar.gocd.github.util;
 
-import com.tw.go.plugin.GitHelper;
-import com.tw.go.plugin.HelperFactory;
-import com.tw.go.plugin.model.GitConfig;
-
 import java.io.File;
+
+import com.tw.go.plugin.model.GitConfig;
 
 public class GitFactory {
 
-    public GitHelper create(GitConfig config, File folder) {
-        return HelperFactory.gitCmd(config, folder);
+    public ExtendedGitCmdHelper create(GitConfig config, File folder) {
+        return new ExtendedGitCmdHelper(config, folder);
     }
 
 }

--- a/src/test/java/in/ashwanthkumar/gocd/github/GitHubPRBuildPluginTest.java
+++ b/src/test/java/in/ashwanthkumar/gocd/github/GitHubPRBuildPluginTest.java
@@ -1,14 +1,11 @@
 package in.ashwanthkumar.gocd.github;
 
 import com.google.gson.Gson;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
 import com.thoughtworks.go.plugin.api.GoApplicationAccessor;
 import com.thoughtworks.go.plugin.api.request.GoApiRequest;
 import com.thoughtworks.go.plugin.api.request.GoPluginApiRequest;
 import com.thoughtworks.go.plugin.api.response.DefaultGoApiResponse;
 import com.thoughtworks.go.plugin.api.response.GoPluginApiResponse;
-import com.tw.go.plugin.GitHelper;
 import com.tw.go.plugin.model.GitConfig;
 import com.tw.go.plugin.model.ModifiedFile;
 import com.tw.go.plugin.model.Revision;
@@ -17,6 +14,7 @@ import in.ashwanthkumar.gocd.github.provider.gerrit.GerritProvider;
 import in.ashwanthkumar.gocd.github.provider.git.GitProvider;
 import in.ashwanthkumar.gocd.github.provider.github.GHUtils;
 import in.ashwanthkumar.gocd.github.provider.github.GitHubProvider;
+import in.ashwanthkumar.gocd.github.util.ExtendedGitCmdHelper;
 import in.ashwanthkumar.gocd.github.util.GitFactory;
 import in.ashwanthkumar.gocd.github.util.GitFolderFactory;
 import in.ashwanthkumar.gocd.github.util.JSONUtils;
@@ -378,7 +376,7 @@ public class GitHubPRBuildPluginTest {
     }
 
     private void mockGitHelperToReturnBranch(GitFactory gitFactory, final String branch) {
-        GitHelper helper = mock(GitHelper.class);
+        ExtendedGitCmdHelper helper = mock(ExtendedGitCmdHelper.class);
         when(gitFactory.create(any(GitConfig.class), any(File.class))).thenReturn(helper);
         when(helper.getBranchToRevisionMap(anyString())).thenReturn(new HashMap<String, String>() {{
             put(branch, "abcdef01234567891");


### PR DESCRIPTION
Fixes the messy git state when the PR plugin checks out.

Before:
* Checkout (clone) the master (or default) branch
* git reset --hard it to the pull request revision

-> master branch is in state of PR. Sonar is confused because it's supposed to be a different branch and because there is no diff between master and the PR.

Now:
* Checkout (clone) the master (or default) branch
* Checkout a new branch (`gocd-pr/<pr id>`, or the actual source branch if known)
* git reset --hard it to the pull request revision

-> PR state is checked out to dedicated branch. Sonar can detect the diff between master and branch.