### PR TITLE
ADNCD-1948: Add workaround for all PRs being rebuilt after GitHub migration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>in.ashwanthkumar</groupId>
     <artifactId>gocd-github-pr-material</artifactId>
-    <version>1.6.0</version>
+    <version>1.6.1_migr1</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/in/ashwanthkumar/gocd/github/GitHubPRBuildPlugin.java
+++ b/src/main/java/in/ashwanthkumar/gocd/github/GitHubPRBuildPlugin.java
@@ -15,6 +15,7 @@ import com.tw.go.plugin.model.Revision;
 import com.tw.go.plugin.util.ListUtil;
 import com.tw.go.plugin.util.StringUtil;
 import in.ashwanthkumar.gocd.github.provider.Provider;
+import in.ashwanthkumar.gocd.github.provider.github.GitHubProvider;
 import in.ashwanthkumar.gocd.github.settings.scm.PluginConfigurationView;
 import in.ashwanthkumar.gocd.github.util.BranchFilter;
 import in.ashwanthkumar.gocd.github.util.ExtendedGitCmdHelper;
@@ -227,7 +228,12 @@ public class GitHubPRBuildPlugin implements GoPlugin {
             }
 
             // Remove all other branches from the response to ensure the next time those will be picked up by GoCD
-            branchToRevisionMap.entrySet().removeIf(entry -> !Objects.equals(entry.getKey(), newerRevision.getKey()));
+            if (provider instanceof GitHubProvider) {
+                LOGGER.info("Storing all seen PRs for initial GitHub PR material load.");
+            }
+            else {
+                branchToRevisionMap.entrySet().removeIf(entry -> !Objects.equals(entry.getKey(), newerRevision.getKey()));
+            }
 
             Revision revision = git.getDetailsForRevision(newerRevision.getValue());
             String branch = newerRevision.getKey();


### PR DESCRIPTION
On initial load of a PR material (handleGetLatestRevision), store all seen PRs, not just the one we're building. For subsequent loads (handleLatestRevisionSince) behave the same as before, and only store the PR we're building.

Also tried fancier variants where you can configure the behavior per PR material, even allowing to clear the state and rebuild everything. However, there seems to be a GoCD caching bug such that PR material config changes in the UI are properly displayed, but not actually propagated to the PR plugin. It keeps using the old config until GoCD is restarted, or the PR material (and due to dependency the referencing config repo) is removed and readded.