### PR TITLE
ADNCD-2084: Fix handleLatestRevisionSince not returning new revisions

### DIFF
--- a/src/main/java/in/ashwanthkumar/gocd/github/GitHubPRBuildPlugin.java
+++ b/src/main/java/in/ashwanthkumar/gocd/github/GitHubPRBuildPlugin.java
@@ -263,7 +263,7 @@ public class GitHubPRBuildPlugin implements GoPlugin {
         LOGGER.debug(String.format("Fetching latest for: %s", gitConfig.getUrl()));
 
         try {
-            GitHelper git = gitFactory.create(gitConfig, gitFolderFactory.create(flyweightFolder));
+            ExtendedGitCmdHelper git = gitFactory.create(gitConfig, gitFolderFactory.create(flyweightFolder));
             Map<String, String> newPrToRevisionMap = buildBranchToRevisionMap(git);
 
             Pair<String, String> newerRevision = findNewerPrRevision(oldPrRevisionMap, newPrToRevisionMap,
@@ -328,7 +328,7 @@ public class GitHubPRBuildPlugin implements GoPlugin {
         return null;
     }
 
-    private List<Map<String, Object>> findAllRevisionsSince(GitHelper git, GitConfig gitConfig, String branch, String lastKnownSHA,
+    private List<Map<String, Object>> findAllRevisionsSince(ExtendedGitCmdHelper git, GitConfig gitConfig, String branch, String lastKnownSHA,
             String latestSHA) {
         List<Map<String, Object>> revisions = new ArrayList<>();
 
@@ -336,7 +336,7 @@ public class GitHubPRBuildPlugin implements GoPlugin {
             git.resetHard(latestSHA);
             List<Revision> allRevisionsSince;
             try {
-                allRevisionsSince = git.getRevisionsSince(lastKnownSHA);
+                allRevisionsSince = git.getRevisionsUntilHeadSince(lastKnownSHA);
             } catch (Exception e) {
                 allRevisionsSince = singletonList(git.getLatestRevision());
             }

--- a/src/main/java/in/ashwanthkumar/gocd/github/util/ExtendedGitCmdHelper.java
+++ b/src/main/java/in/ashwanthkumar/gocd/github/util/ExtendedGitCmdHelper.java
@@ -1,14 +1,23 @@
 package in.ashwanthkumar.gocd.github.util;
 
 import java.io.File;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import com.tw.go.plugin.cmd.Console;
+import com.tw.go.plugin.cmd.ConsoleResult;
+import com.tw.go.plugin.cmd.InMemoryConsumer;
 import com.tw.go.plugin.cmd.ProcessOutputStreamConsumer;
 import com.tw.go.plugin.git.GitCmdHelper;
+import com.tw.go.plugin.git.GitModificationParser;
 import com.tw.go.plugin.model.GitConfig;
+import com.tw.go.plugin.model.Revision;
 import org.apache.commons.exec.CommandLine;
 
 public class ExtendedGitCmdHelper extends GitCmdHelper {
+
+    private static final Pattern GIT_DIFF_TREE_PATTERN = Pattern.compile("^(.{1,3})\\s+(.+)$");
 
     public ExtendedGitCmdHelper(GitConfig gitConfig, File workingDir) {
         super(gitConfig, workingDir);
@@ -22,5 +31,75 @@ public class ExtendedGitCmdHelper extends GitCmdHelper {
     public void checkoutNewBranch(String branchName) {
         CommandLine gitCheckout = Console.createCommand("checkout", "-B", branchName);
         Console.runOrBomb(gitCheckout, workingDir, stdOut, stdErr);
+    }
+
+    public List<Revision> getRevisionsUntilHeadSince(String revision) {
+        String[] logArgs = new String[]{
+                "log", "--date=iso", "--pretty=medium", "--no-decorate", "--no-color", String.format("%s..", revision)
+        };
+        return this.gitLog(logArgs);
+    }
+
+    private List<Revision> gitLog(String... args) {
+        CommandLine gitLog = Console.createCommand(args);
+        List<String> gitLogOutput = this.runAndGetOutput(gitLog).stdOut();
+
+        List<Revision> revisions = new GitModificationParser().parse(gitLogOutput);
+        for (Revision revision : revisions) {
+            addModifiedFiles(revision);
+        }
+
+        return revisions;
+    }
+
+    private ConsoleResult runAndGetOutput(CommandLine gitCmd) {
+        return this.runAndGetOutput(gitCmd, this.workingDir);
+    }
+
+    private ConsoleResult runAndGetOutput(CommandLine gitCmd, File workingDir) {
+        return this.runAndGetOutput(gitCmd, workingDir, new ProcessOutputStreamConsumer(new InMemoryConsumer()), new ProcessOutputStreamConsumer(new InMemoryConsumer()));
+    }
+
+    private ConsoleResult runAndGetOutput(CommandLine gitCmd, File workingDir, ProcessOutputStreamConsumer stdOut, ProcessOutputStreamConsumer stdErr) {
+        return Console.runOrBomb(gitCmd, workingDir, stdOut, stdErr);
+    }
+
+    private void addModifiedFiles(Revision revision) {
+        List<String> diffTreeOutput = diffTree(revision.getRevision()).stdOut();
+
+        for (String resultLine : diffTreeOutput) {
+            // First line is the node
+            if (resultLine.equals(revision.getRevision())) {
+                continue;
+            }
+
+            Matcher m = matchResultLine(resultLine);
+            if (!m.find()) {
+                throw new RuntimeException(String.format("Unable to parse git-diff-tree output line: %s%nFrom output:%n %s", resultLine, String.join(System.lineSeparator(), diffTreeOutput)));
+            }
+            revision.createModifiedFile(m.group(2), parseGitAction(m.group(1).charAt(0)));
+        }
+    }
+
+    private ConsoleResult diffTree(String node) {
+        CommandLine gitCmd = Console.createCommand("diff-tree", "--name-status", "--root", "-r", "-c", node);
+        return runAndGetOutput(gitCmd);
+    }
+
+    private Matcher matchResultLine(String resultLine) {
+        return GIT_DIFF_TREE_PATTERN.matcher(resultLine);
+    }
+
+    private String parseGitAction(char action) {
+        switch (action) {
+            case 'A':
+                return "added";
+            case 'M':
+                return "modified";
+            case 'D':
+                return "deleted";
+            default:
+                return "unknown";
+        }
     }
 }


### PR DESCRIPTION
The issue was introduced with the upgrade of git-cmd to 2.0, where the getRevisionsSince method was changed to compare the old commit to the remote branch, instead of comparing it to the HEAD of the checkout. Therefore the plugin doesn't properly detect revisions from latest PR commit (HEAD) to last seen commit.

To fix this, reintroduced the old getRevisionSince method as getRevisionsUntilHeadSince to our ExtendedGitCmdHelper class. It requires a lot of duplication from GitCmdHelper because most of its helper methods are private.

The alternative is to downgrade git-cmd to 1.4 again, but it would be nice to keep the other fixes and upgrades of git-cmd.

This is a workaround while I open an issue in the upstream plugin. However I don't have high hopes of getting a fix quickly or at all, given that the maintainership of the upstream is not super clear and further it's not even a bug directly in the plugin but in one of its dependencies (which is also maintained by the same person though).